### PR TITLE
Allauth login linking

### DIFF
--- a/core/account/login.html
+++ b/core/account/login.html
@@ -1,0 +1,47 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load account socialaccount %}
+
+{% block head_title %}{% trans "Sign In" %}{% endblock %}
+
+{% block content %}
+
+<h1>{% trans "Sign In" %}</h1>
+
+{% get_providers as socialaccount_providers %}
+
+{% if socialaccount_providers %}
+<p>{% blocktrans with site.name as site_name %}Please sign in with one
+of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
+for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
+
+<div class="socialaccount_ballot">
+
+  <ul class="socialaccount_providers">
+    {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+  </ul>
+
+  <div class="login-or">{% trans 'or' %}</div>
+
+</div>
+
+{% include "socialaccount/snippets/login_extra.html" %}
+
+{% else %}
+<p>{% blocktrans %}If you have not created an account yet, then please
+<a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
+{% endif %}
+
+<form class="login" method="POST" action="{% url 'account_login' %}">
+  {% csrf_token %}
+  {{ form.as_p }}
+  {% if redirect_field_value %}
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+  {% endif %}
+  <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+  <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
+</form>
+
+{% endblock %}
+© 2019 GitHub

--- a/core/models.py
+++ b/core/models.py
@@ -1,3 +1,5 @@
 from django.db import models
-
+from django.contrib.auth import get_user_model
 # Create your models here.
+
+User = get_user_model()

--- a/core/templates/account/login.html
+++ b/core/templates/account/login.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 {% load account socialaccount %}
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<h1>{% trans "Sign In" %}</h1>
+<h1>SIGN IN</h1>
 
 {% get_providers as socialaccount_providers %}
 

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,22 +1,45 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Flashcards {%block title %}{% endblock %}</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>TCBY Flashcards {% block head_title %}{% endblock %}</title>
+    {% block extra_head %}
+    {% endblock %}
     <link rel="stylesheet" href="https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css"/> <!--Tachyons if we want it-->
     <!-- Add CSS in static file -->
     {% load static %}
     <link rel="stylesheet" href="{% static 'css/styles.css' %}">
-    {% block meta %}{% endblock %} <!--Redux block-->
-</head>
-<body>
-    <header>
-        <div>
-            <a href="{% url 'account_login' %}">Login</a>
-        </div>
-    </header>
-    <div>{% block content %}{% endblock %}</div>
-</body>
+  </head>
+  <body>
+    {% block body %}
+    {% if messages %}
+    <div>
+      <strong>Messages:</strong>
+      <ul>
+        {% for message in messages %}
+        <li>{{message}}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+    <div>
+      <strong>TCBY Flashcards</strong>
+      <ul>
+        {% if user.is_authenticated %}
+        <li><a href="{% url 'account_email' %}">Change E-mail</a></li>
+        <li><a href="{% url 'account_logout' %}">Sign Out</a></li>
+        {% else %}
+        <li><a href="{% url 'account_login' %}">Sign In</a></li>
+        <li><a href="{% url 'account_signup' %}">Sign Up</a></li>
+        {% endif %}
+      </ul>
+    </div>
+    {% block content %}
+    {% endblock %}
+    {% endblock %}
+    {% block extra_body %}
+    {% endblock %}
+  </body>
 </html>

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -12,6 +12,11 @@
     {% block meta %}{% endblock %} <!--Redux block-->
 </head>
 <body>
+    <header>
+        <div>
+            <a href="{% url 'account_login' %}">Login</a>
+        </div>
+    </header>
     <div>{% block content %}{% endblock %}</div>
 </body>
 </html>

--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-  
+      path('', views.index, name='index'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,3 +1,6 @@
 from django.shortcuts import render
 
 # Create your views here.
+
+def index(request):
+    return render(request, 'index.html')

--- a/flashcard/settings.py
+++ b/flashcard/settings.py
@@ -44,7 +44,7 @@ INSTALLED_APPS = [
     'allauth.account',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.google',
-    'allauth.socialaccount.providers.facebook',
+    # 'allauth.socialaccount.providers.facebook', commenting out for now while working on google auth
     # core apps
     'core.apps.CoreConfig', # MDN tutorial way
     # 'core', --Clinton's way
@@ -139,3 +139,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+
+LOGIN_REDIRECT_URL = '/core/'
+LOGOUT_REDIRECT_URL = '/core/'

--- a/flashcard/settings.py
+++ b/flashcard/settings.py
@@ -31,6 +31,8 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    # core apps
+    'core.apps.CoreConfig', # moving up here so we can override ALLAUTH templates
     # django standard apps
     'django.contrib.admin',
     'django.contrib.auth',
@@ -45,9 +47,6 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     'allauth.socialaccount.providers.google',
     # 'allauth.socialaccount.providers.facebook', commenting out for now while working on google auth
-    # core apps
-    'core.apps.CoreConfig', # MDN tutorial way
-    # 'core', --Clinton's way
 ]
 
 SITE_ID = 1
@@ -103,6 +102,8 @@ AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
     'allauth.account.auth_backends.AuthenticationBackend',
 ]
+# will print emails to console for development 
+EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend'
 
 
 AUTH_PASSWORD_VALIDATORS = [
@@ -141,4 +142,3 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 LOGIN_REDIRECT_URL = '/core/'
-LOGOUT_REDIRECT_URL = '/core/'

--- a/flashcard/urls.py
+++ b/flashcard/urls.py
@@ -24,7 +24,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('core/', include('core.urls')),
     path('', RedirectView.as_view(url='/core/', permanent=True)),
-    path('core/', views.index, name='index'),
     # allauth registration
     path('accounts/', include('allauth.urls')),
 ] 

--- a/flashcard/urls.py
+++ b/flashcard/urls.py
@@ -18,11 +18,13 @@ from django.urls import path, include
 from django.views.generic import RedirectView
 from django.conf import settings
 from django.conf.urls.static import static
+from core import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('core/', include('core.urls')),
     path('', RedirectView.as_view(url='/core/', permanent=True)),
+    path('core/', views.index, name='index'),
     # allauth registration
     path('accounts/', include('allauth.urls')),
 ] 


### PR DESCRIPTION
Added index.html and very generic index view in views. Reorganized the base.html for allauth block content and pulled in the allauth login html page if we want to customize ourselves.  Attempted to get app id and secret key for google auth login and allows it to show up but need to figure out callback/redirect url I believe, after you select google login.  Facebook ran into an issue as it seems there 's some js sdk that needs to be input so commented out in settings for now.
https://django-allauth.readthedocs.io/en/latest/providers.html#google